### PR TITLE
fix reset flag upstreamResponseReceived when re-choosehost

### DIFF
--- a/pkg/proxy/streamfilters.go
+++ b/pkg/proxy/streamfilters.go
@@ -43,6 +43,7 @@ func (s *downStream) runAppendFilters(p types.Phase, headers types.HeaderMap, da
 				if host.Health() {
 					s.receiverFiltersAgainPhase = types.ChooseHost
 					s.senderFiltersIndex = 0
+					atomic.CompareAndSwapUint32(&s.upstreamResponseReceived, 1, 0)
 					return
 				}
 			}


### PR DESCRIPTION
### Issues associated with this PR

fix reset flag upstreamResponseReceived when re-choosehost

### Solutions

### UT result

### Benchmark

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
