### PR TITLE
- feature: support get native sds client and subscriber

### DIFF
--- a/pkg/mtls/provider.go
+++ b/pkg/mtls/provider.go
@@ -19,6 +19,7 @@ package mtls
 
 import (
 	"mosn.io/mosn/pkg/config/v2"
+	"mosn.io/mosn/pkg/log"
 	"mosn.io/mosn/pkg/types"
 )
 
@@ -39,6 +40,7 @@ func (p *staticProvider) Empty() bool {
 // NewProvider returns a types.Provider.
 // we support sds provider and static provider.
 func NewProvider(cfg *v2.TLSConfig) (types.TLSProvider, error) {
+	log.DefaultLogger.Infof("[mtls] [NewProvider] config:%v", cfg)
 	if !cfg.Status {
 		return nil, nil
 	}

--- a/pkg/mtls/sds/client.go
+++ b/pkg/mtls/sds/client.go
@@ -115,10 +115,11 @@ func (client *SdsClientImpl) GetSdsClient() v2.SecretDiscoveryServiceClient {
 		return client.sdsClient
 	}
 	nativeClient, err := GetSdsNativeClient(client.sdsConfig)
-	if err == nil {
+	if err != nil {
 		log.DefaultLogger.Errorf("[xds] [sds client],native client init failed,error = %v", err)
 		return nil
 	}
+	client.sdsClient = nativeClient
 	return nativeClient
 }
 

--- a/pkg/mtls/sds/client.go
+++ b/pkg/mtls/sds/client.go
@@ -78,7 +78,9 @@ func CloseSdsClient() {
 func (client *SdsClientImpl) AddUpdateCallback(name string, callback types.SdsUpdateCallbackFunc) error {
 	client.updatedLock.Lock()
 	defer client.updatedLock.Unlock()
-	client.SdsCallbackMap[name] = callback
+	if callback != nil {
+		client.SdsCallbackMap[name] = callback
+	}
 	client.sdsSubscriber.SendSdsRequest(name)
 	return nil
 }

--- a/pkg/mtls/sds/client_test.go
+++ b/pkg/mtls/sds/client_test.go
@@ -18,6 +18,7 @@
 package sds
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
@@ -33,6 +34,8 @@ func testClean() {
 func TestSdsClient(t *testing.T) {
 	// Init
 	RegisterSdsStreamClientFactory(NewMockSdsStreamClient)
+
+	RegisterSdsNativeClientFactory(NewMockSdsNativeClient)
 
 	t.Run("create a new sds client, mock a certificate request registered", func(t *testing.T) {
 		testClean()
@@ -98,5 +101,17 @@ func TestSdsClient(t *testing.T) {
 		require.Len(t, c.SdsCallbackMap, 1)
 		require.Nil(t, client.DeleteUpdateCallback("test"))
 		require.Len(t, c.SdsCallbackMap, 0)
+	})
+
+	t.Run("test get sds native client", func(t *testing.T) {
+		client := NewSdsClientSingleton(&MockSdsConfig{
+			Timeout: time.Second,
+		})
+		c, ok := client.(*SdsClientImpl)
+		if !ok {
+			t.Errorf("Got error client type failed")
+		}
+		sdsClient := c.GetSdsClient()
+		assert.NotNilf(t, sdsClient, "GetSdsClient failed")
 	})
 }

--- a/pkg/mtls/sds/factory.go
+++ b/pkg/mtls/sds/factory.go
@@ -17,11 +17,15 @@
 
 package sds
 
+import v2 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+
 // var getSdsClientFunc func(cfg *auth.SdsSecretConfig) types.SdsClient = sds.NewSdsClientSingleton
 
 var globalSds struct {
 	// getSdsStreamClient for extensions
 	getSdsStreamClient func(config interface{}) (SdsStreamClient, error)
+
+	getSdsNativeClient func(config interface{}) (v2.SecretDiscoveryServiceClient, error)
 }
 
 // func GetSdsClient(cfg *auth.SdsSecretConfig) types.SdsClient {}
@@ -30,6 +34,14 @@ func RegisterSdsStreamClientFactory(f func(config interface{}) (SdsStreamClient,
 	globalSds.getSdsStreamClient = f
 }
 
+func RegisterSdsNativeClientFactory(f func(config interface{}) (v2.SecretDiscoveryServiceClient, error)) {
+	globalSds.getSdsNativeClient = f
+}
+
 func GetSdsStreamClient(config interface{}) (SdsStreamClient, error) {
 	return globalSds.getSdsStreamClient(config)
+}
+
+func GetSdsNativeClient(config interface{}) (v2.SecretDiscoveryServiceClient, error) {
+	return globalSds.getSdsNativeClient(config)
 }

--- a/pkg/mtls/secret_manager.go
+++ b/pkg/mtls/secret_manager.go
@@ -124,8 +124,7 @@ func (mng *secretManager) setValidation(name string, secret *types.SdsSecret) {
 	}
 	if secret.ValidationPEM != "" {
 		v.pem = secret.ValidationPEM
-		log.DefaultLogger.Infof("[mtls] [sds provider] provider %s receive a validation set", name)
-		log.DefaultLogger.Infof("[mtls] [sds provider] ca validation %s", v)
+		log.DefaultLogger.Infof("[mtls] [sds provider] provider %s receive a validation set, set = %s", name, v)
 		// set the validation
 		for _, cert := range v.certificates {
 			cert.setValidation(v.pem)
@@ -153,8 +152,7 @@ func (p *sdsProvider) setCertificate(name string, secret *types.SdsSecret) {
 	if secret.CertificatePEM != "" {
 		p.info.Certificate = secret.CertificatePEM
 		p.info.PrivateKey = secret.PrivateKeyPEM
-		log.DefaultLogger.Infof("[mtls] [sds provider] provider %s receive a cerificate set", name)
-		log.DefaultLogger.Infof("[mtls] [sds provider] certificate %s private key %s", secret.CertificatePEM, secret.PrivateKeyPEM)
+		log.DefaultLogger.Infof("[mtls] [sds provider] provider %s receive a cerificate set,certificate = %s ", name, secret.CertificatePEM)
 	}
 	if p.info.full() {
 		p.update()

--- a/pkg/mtls/secret_manager.go
+++ b/pkg/mtls/secret_manager.go
@@ -125,6 +125,7 @@ func (mng *secretManager) setValidation(name string, secret *types.SdsSecret) {
 	if secret.ValidationPEM != "" {
 		v.pem = secret.ValidationPEM
 		log.DefaultLogger.Infof("[mtls] [sds provider] provider %s receive a validation set", name)
+		log.DefaultLogger.Infof("[mtls] [sds provider] ca validation %s", v)
 		// set the validation
 		for _, cert := range v.certificates {
 			cert.setValidation(v.pem)
@@ -153,6 +154,7 @@ func (p *sdsProvider) setCertificate(name string, secret *types.SdsSecret) {
 		p.info.Certificate = secret.CertificatePEM
 		p.info.PrivateKey = secret.PrivateKeyPEM
 		log.DefaultLogger.Infof("[mtls] [sds provider] provider %s receive a cerificate set", name)
+		log.DefaultLogger.Infof("[mtls] [sds provider] certificate %s private key %s", secret.CertificatePEM, secret.PrivateKeyPEM)
 	}
 	if p.info.full() {
 		p.update()

--- a/pkg/mtls/tls_context.go
+++ b/pkg/mtls/tls_context.go
@@ -156,6 +156,7 @@ func newTLSContext(cfg *v2.TLSConfig, secret *secretInfo) (*tlsContext, error) {
 	// pool can be nil, if it is nil, TLS uses the host's root CA set.
 	pool, err := hooks.GetX509Pool(secret.Validation)
 	if err != nil {
+		log.DefaultLogger.Errorf("hooks.GetX509Pool failed %v", err)
 		return nil, err
 	}
 	tmpl.RootCAs = pool


### PR DESCRIPTION
- feature: support get native sds client and subscriber
- feature: add some logs

### Issues associated with this PR

User can get native sds client  when need to invoker other methods;
User can get subscriber,  send request directlly;
When secret resourceName is same, allow callback is nil. And using old callback method when SetSecret method invoke;

### Solutions
Add method `GetSdsClient`,`GetSdsSubscriber ` in `pkg/mtls/sds/client.go`
Add some log for debug

